### PR TITLE
Setup Neovim environment with plugins, LSP, Neorg, and session fixes - Add Neovim config, plugins, LSP updates, keymaps, and Neorg support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,5 @@
 vim.opt.conceallevel = 2
+vim.o.sessionoptions = "blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"
 
 require("reconfig-vim.core")
 require("reconfig-vim.lazy")

--- a/init.lua
+++ b/init.lua
@@ -1,2 +1,4 @@
+vim.opt.conceallevel = 2
+
 require("reconfig-vim.core")
 require("reconfig-vim.lazy")

--- a/lua/reconfig-vim/core/keymaps.lua
+++ b/lua/reconfig-vim/core/keymaps.lua
@@ -27,3 +27,13 @@ keymap.set("n", "<A-j>", ":move .+1<CR>==")
 keymap.set("n", "<A-k>", ":move .-2<CR>==")
 keymap.set("v", "<A-j>", ":move '>+1<CR>gv=gv")
 keymap.set("v", "<A-k>", ":move '<-2<CR>gv=gv")
+
+-- quickFix lsp
+keymap.set("n", "<leader>qf", function()
+	vim.lsp.buf.code_action({
+		context = {
+			only = { "quickfix" },
+			diagnostics = vim.lsp.diagnostic.get_line_diagnostics(),
+		},
+	})
+end, { desc = "LSP Quickfix" })

--- a/lua/reconfig-vim/core/keymaps.lua
+++ b/lua/reconfig-vim/core/keymaps.lua
@@ -30,10 +30,11 @@ keymap.set("v", "<A-k>", ":move '<-2<CR>gv=gv")
 
 -- quickFix lsp
 keymap.set("n", "<leader>qf", function()
+	local line = vim.api.nvim_win_get_cursor(0)[1] - 1
 	vim.lsp.buf.code_action({
 		context = {
 			only = { "quickfix" },
-			diagnostics = vim.lsp.diagnostic.get_line_diagnostics(),
+			diagnostics = vim.diagnostic.get(0, { lnum = line }),
 		},
 	})
 end, { desc = "LSP Quickfix" })

--- a/lua/reconfig-vim/core/keymaps.lua
+++ b/lua/reconfig-vim/core/keymaps.lua
@@ -21,3 +21,9 @@ keymap.set("n", "<leader>tx", "<cmd>tabclose<CR>", { desc = "Close current tab" 
 keymap.set("n", "<leader>tn", "<cmd>tabn<CR>", { desc = "Go to next tab" }) -- go to next tab
 keymap.set("n", "<leader>tp", "<cmd>tabp<CR>", { desc = "Go to previous tab" }) -- go pre tab
 keymap.set("n", "<leader>tf", "<cmd>tabnew<CR>", { desc = "Open current buffer in new tab" }) -- open current buffer in new tab
+
+-- line movement
+keymap.set("n", "<A-j>", ":move .+1<CR>==")
+keymap.set("n", "<A-k>", ":move .-2<CR>==")
+keymap.set("v", "<A-j>", ":move '>+1<CR>gv=gv")
+keymap.set("v", "<A-k>", ":move '<-2<CR>gv=gv")

--- a/lua/reconfig-vim/plugins/image.lua
+++ b/lua/reconfig-vim/plugins/image.lua
@@ -2,12 +2,13 @@ return {
 	"3rd/image.nvim",
 	build = false, -- so that it doesn't build the rock https://github.com/3rd/image.nvim/issues/91#issuecomment-2453430239
 	opts = {
-		processor = "magick_cli",
-	},
-	integrations = {
-		neorg = {
-			enabled = true,
-			filetyoes = { "norg" },
+		backend = "kitty", -- choose your terminal backend: kitty, ueberzug, or sixel
+		processor = "magick_cli", -- image processing method
+		integrations = {
+			neorg = {
+				enabled = true, -- enable image preview in Neorg
+				filetypes = { "norg" },
+			},
 		},
 	},
 }

--- a/lua/reconfig-vim/plugins/image.lua
+++ b/lua/reconfig-vim/plugins/image.lua
@@ -1,0 +1,13 @@
+return {
+	"3rd/image.nvim",
+	build = false, -- so that it doesn't build the rock https://github.com/3rd/image.nvim/issues/91#issuecomment-2453430239
+	opts = {
+		processor = "magick_cli",
+	},
+	integrations = {
+		neorg = {
+			enabled = true,
+			filetyoes = { "norg" },
+		},
+	},
+}

--- a/lua/reconfig-vim/plugins/lsp/lspconfig.lua
+++ b/lua/reconfig-vim/plugins/lsp/lspconfig.lua
@@ -136,11 +136,33 @@ return {
 		})
 		vim.lsp.enable("graphql")
 
-		-- Emmet server
+		-- emmet server
 		vim.lsp.config("emmet_ls", {
 			capabilities = capabilities,
 			filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte" },
 		})
 		vim.lsp.enable("emmet_ls")
+
+		-- your dictionary
+		local custom_settings = {
+			ltex = {
+				dictionary = {
+					["en-US"] = { "pandoc", "norg", "Uncategorised", "minorg", "json", "( )", "Neorg" }, -- use full lang code (important!)
+				},
+				disabledRules = {
+					["en-US"] = { "COMMA_PARENTHESIS_WHITESPACE" },
+				},
+			},
+		}
+
+		-- merge with defaults
+		local final_settings = vim.tbl_deep_extend("force", {}, custom_settings)
+
+		vim.lsp.config("ltex_plus", {
+			capabilities = capabilities,
+			filetypes = { "markdown", "org", "norg", "text" },
+			settings = final_settings,
+		})
+		vim.lsp.enable("ltex_plus")
 	end,
 }

--- a/lua/reconfig-vim/plugins/lsp/lspconfig.lua
+++ b/lua/reconfig-vim/plugins/lsp/lspconfig.lua
@@ -14,12 +14,30 @@ return {
 		-- Capabilities for autocompletion
 		local capabilities = cmp_nvim_lsp.default_capabilities()
 
-		-- Set diagnostic symbols
-		local signs = { Error = " ", Warn = " ", Hint = "󰠠 ", Info = " " }
-		for type, icon in pairs(signs) do
-			local hl = "DiagnosticSign" .. type
-			vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
+		-- Define diagnostic symbols (icons)
+		local signs = {
+			{ name = "DiagnosticSignError", text = "" },
+			{ name = "DiagnosticSignWarn", text = "" },
+			{ name = "DiagnosticSignHint", text = "󰠠" },
+			{ name = "DiagnosticSignInfo", text = "" },
+		}
+
+		for _, sign in ipairs(signs) do
+			vim.fn.sign_define(sign.name, { texthl = sign.name, text = sign.text, numhl = "" })
 		end
+
+		-- Enable diagnostic signs
+		vim.diagnostic.config({
+			signs = {
+				active = signs,
+			},
+		})
+
+		-- Custom highlight colors
+		vim.api.nvim_set_hl(0, "DiagnosticSignError", { fg = "#F44747" })
+		vim.api.nvim_set_hl(0, "DiagnosticSignWarn", { fg = "#FF8800" })
+		vim.api.nvim_set_hl(0, "DiagnosticSignHint", { fg = "#4FC1FF" })
+		vim.api.nvim_set_hl(0, "DiagnosticSignInfo", { fg = "#DCDCAA" })
 
 		-- LSP keymaps
 		vim.api.nvim_create_autocmd("LspAttach", {

--- a/lua/reconfig-vim/plugins/luaSnip.lua
+++ b/lua/reconfig-vim/plugins/luaSnip.lua
@@ -1,0 +1,8 @@
+return {
+	"L3MON4D3/LuaSnip",
+	version = "2.*", -- latest stable
+	dependencies = { "rafamadriz/friendly-snippets" }, -- optional prebuilt snippets
+	config = function()
+		require("luasnip.loaders.from_vscode").lazy_load() -- loads snippets
+	end,
+}

--- a/lua/reconfig-vim/plugins/mini-icon.lua
+++ b/lua/reconfig-vim/plugins/mini-icon.lua
@@ -1,0 +1,4 @@
+return {
+	"echasnovski/mini.icons",
+	version = false, -- always latest
+}

--- a/lua/reconfig-vim/plugins/neorg.lua
+++ b/lua/reconfig-vim/plugins/neorg.lua
@@ -37,8 +37,8 @@ return {
 				["core.dirman"] = {
 					config = {
 						workspaces = {
+							--NOTE: write your path (Tomb-specific and only exist when the vault mounted!)
 							default = "/run/media/p0uya/Neorg-di-Vault/Neorg-di-Vault",
-							testNeorg = "~/Projects/temp-project/neorg-test",
 						},
 						default_workspace = "default",
 					},
@@ -76,6 +76,7 @@ return {
 				["core.text-objects"] = {}, -- required for item/heading movement
 				["external.templates"] = {
 					config = {
+						--NOTE: write your path (Tomb-specific and only exist when the vault mounted!)
 						templates_dir = "/run/media/p0uya/Neorg-di-Vault/Neorg-di-Vault/Templates",
 						default_subcommand = "add", -- or "fload" / "load"
 					},

--- a/lua/reconfig-vim/plugins/neorg.lua
+++ b/lua/reconfig-vim/plugins/neorg.lua
@@ -1,0 +1,133 @@
+local latex_rendered = false
+
+return {
+	"nvim-neorg/neorg",
+	lazy = false, -- disable lazy loading
+
+	version = "*", -- latest stable release
+	dependencies = {
+		--TODO: need lua 5.1
+		{ "nvim-lua/plenary.nvim" },
+		{ "nvim-neotest/nvim-nio" },
+		{ "MunifTanjim/nui.nvim" },
+		{ "nvim-neorg/lua-utils.nvim" },
+		{ "pysan3/pathlib.nvim" },
+		{ "nvim-neorg/neorg-telescope" },
+		{ "nvim-neorg/norg-fmt" },
+		{ "phenax/neorg-timelog" },
+		{ "pysan3/neorg-templates", dependencies = { "L3MON4D3/LuaSnip" } },
+	},
+	config = function()
+		local map = vim.keymap.set
+		local opts = { silent = true, noremap = false }
+
+		-- Neorg setup
+		require("neorg").setup({
+			load = {
+				["core.defaults"] = {},
+				["core.ui"] = {},
+				["core.looking-glass"] = {},
+				["core.concealer"] = {},
+				["core.integrations.telescope"] = {
+					config = {
+						install_parser = true,
+						configure_parser = true,
+					},
+				},
+				["core.dirman"] = {
+					config = {
+						workspaces = {
+							default = "/run/media/p0uya/Neorg-di-Vault/Neorg-di-Vault",
+							testNeorg = "~/Projects/temp-project/neorg-test",
+						},
+						default_workspace = "default",
+					},
+				},
+				["core.completion"] = {
+					config = {
+						engine = "nvim-cmp",
+						name = "[Neorg]",
+					},
+				},
+				["core.latex.renderer"] = {
+					config = {
+						conceal = true,
+						renderer = "core.integrations.image",
+					},
+				},
+				["core.export"] = {},
+				["core.export.markdown"] = {
+					config = {
+						extensions = "all",
+						mathematics = "block",
+					},
+				},
+				["core.summary"] = {
+					config = { strategy = "default" },
+				},
+				["core.journal"] = {
+					config = {
+						journal_folder = "Journal",
+						template_name = "Journal-Template.norg",
+						strategy = "flat",
+						use_template = true,
+					},
+				},
+				["core.text-objects"] = {}, -- required for item/heading movement
+				["external.templates"] = {
+					config = {
+						templates_dir = "/run/media/p0uya/Neorg-di-Vault/Neorg-di-Vault/Templates",
+						default_subcommand = "add", -- or "fload" / "load"
+					},
+				},
+			},
+		})
+
+		-- Keymaps
+		-- Open workspace in Neorg
+		map("n", "<leader>no", function()
+			vim.cmd("Neorg index")
+		end, { desc = "Open Neorg index" })
+
+		-- Return from Neorg
+		map("n", "<leader>nr", function()
+			vim.cmd("Neorg return")
+		end, { desc = "Return from Neorg" })
+
+		-- Open Neorg menu
+		map("n", "<leader>nm", function()
+			vim.cmd("Neorg")
+		end, { desc = "Open Neorg menu" })
+
+		-- Telescope integration
+		map("n", "<leader>nth", "<Plug>(neorg.telescope.search_headings)", opts)
+		map("n", "<leader>ntf", "<Plug>(neorg.telescope.find_norg_files)", opts)
+		map("n", "<leader>ntw", "<Plug>(neorg.telescope.switch_workspace)", opts)
+		map("n", "<leader>ntl", "<Plug>(neorg.telescope.find_linkable)", opts)
+		map("n", "<leader>nti", "<Plug>(neorg.telescope.insert_link)", opts)
+		map("n", "<leader>ntI", "<Plug>(neorg.telescope.insert_file_link)", opts)
+		map("n", "<leader>ntbf", "<Plug>(neorg.telescope.backlinks.file_backlinks)", opts)
+		map("n", "<leader>ntbh", "<Plug>(neorg.telescope.backlinks.header_backlinks)", opts)
+
+		-- Toggle LaTeX rendering
+		map("n", "<leader>nl", function()
+			if latex_rendered then
+				vim.cmd("Neorg render-latex disable")
+				latex_rendered = false
+			else
+				vim.cmd("Neorg render-latex")
+				latex_rendered = true
+			end
+		end, { desc = "Toggle Neorg LaTeX rendering" })
+
+		-- Text-object movement (list items, headings)
+		map("n", "<C-k>", "<Plug>(neorg.text-objects.item-up)", opts)
+		map("n", "<C-j>", "<Plug>(neorg.text-objects.item-down)", opts)
+		map({ "o", "x" }, "iH", "<Plug>(neorg.text-objects.textobject.heading.inner)", opts)
+		map({ "o", "x" }, "aH", "<Plug>(neorg.text-objects.textobject.heading.outer)", opts)
+
+		-- Optional: add more text-object keymaps here
+		-- map({ "o", "x" }, "iT", "<Plug>(neorg.text-objects.textobject.tag.inner)", opts)
+		-- map({ "o", "x" }, "aT", "<Plug>(neorg.text-objects.textobject.tag.outer)", opts)
+	end,
+}

--- a/lua/reconfig-vim/plugins/nvim-cmp.lua
+++ b/lua/reconfig-vim/plugins/nvim-cmp.lua
@@ -1,63 +1,64 @@
 return {
-  "hrsh7th/nvim-cmp",
-  event = "InsertEnter",
-  dependencies = {
-    "hrsh7th/cmp-buffer", -- source for text in buffer
-    "hrsh7th/cmp-path", -- source for file system paths
-    {
-      "L3MON4D3/LuaSnip",
-      -- follow latest release.
-      version = "v2.*", -- Replace <CurrentMajor> by the latest released major (first number of latest release)
-      -- install jsregexp (optional!).
-      build = "make install_jsregexp",
-    },
-    "saadparwaiz1/cmp_luasnip", -- for autocompletion
-    "rafamadriz/friendly-snippets", -- useful snippets
-    "onsails/lspkind.nvim", -- vs-code like pictograms
-  },
-  config = function()
-    local cmp = require("cmp")
+	"hrsh7th/nvim-cmp",
+	event = "InsertEnter",
+	dependencies = {
+		"hrsh7th/cmp-buffer", -- source for text in buffer
+		"hrsh7th/cmp-path", -- source for file system paths
+		{
+			"L3MON4D3/LuaSnip",
+			-- follow latest release.
+			version = "v2.*", -- Replace <CurrentMajor> by the latest released major (first number of latest release)
+			-- install jsregexp (optional!).
+			build = "make install_jsregexp",
+		},
+		"saadparwaiz1/cmp_luasnip", -- for autocompletion
+		"rafamadriz/friendly-snippets", -- useful snippets
+		"onsails/lspkind.nvim", -- vs-code like pictograms
+	},
+	config = function()
+		local cmp = require("cmp")
 
-    local luasnip = require("luasnip")
+		local luasnip = require("luasnip")
 
-    local lspkind = require("lspkind")
+		local lspkind = require("lspkind")
 
-    -- loads vscode style snippets from installed plugins (e.g. friendly-snippets)
-    require("luasnip.loaders.from_vscode").lazy_load()
+		-- loads vscode style snippets from installed plugins (e.g. friendly-snippets)
+		require("luasnip.loaders.from_vscode").lazy_load()
 
-    cmp.setup({
-      completion = {
-        completeopt = "menu,menuone,preview,noselect",
-      },
-      snippet = { -- configure how nvim-cmp interacts with snippet engine
-        expand = function(args)
-          luasnip.lsp_expand(args.body)
-        end,
-      },
-      mapping = cmp.mapping.preset.insert({
-        ["<C-k>"] = cmp.mapping.select_prev_item(), -- previous suggestion
-        ["<C-j>"] = cmp.mapping.select_next_item(), -- next suggestion
-        ["<C-b>"] = cmp.mapping.scroll_docs(-4),
-        ["<C-f>"] = cmp.mapping.scroll_docs(4),
-        ["<C-Space>"] = cmp.mapping.complete(), -- show completion suggestions
-        ["<C-e>"] = cmp.mapping.abort(), -- close completion window
-        ["<CR>"] = cmp.mapping.confirm({ select = false }),
-      }),
-      -- sources for autocompletion
-      sources = cmp.config.sources({
-        { name = "nvim_lsp"},
-        { name = "luasnip" }, -- snippets
-        { name = "buffer" }, -- text within current buffer
-        { name = "path" }, -- file system paths
-      }),
+		cmp.setup({
+			completion = {
+				completeopt = "menu,menuone,preview,noselect",
+			},
+			snippet = { -- configure how nvim-cmp interacts with snippet engine
+				expand = function(args)
+					luasnip.lsp_expand(args.body)
+				end,
+			},
+			mapping = cmp.mapping.preset.insert({
+				["<C-k>"] = cmp.mapping.select_prev_item(), -- previous suggestion
+				["<C-j>"] = cmp.mapping.select_next_item(), -- next suggestion
+				["<C-b>"] = cmp.mapping.scroll_docs(-4),
+				["<C-f>"] = cmp.mapping.scroll_docs(4),
+				["<C-Space>"] = cmp.mapping.complete(), -- show completion suggestions
+				["<C-e>"] = cmp.mapping.abort(), -- close completion window
+				["<CR>"] = cmp.mapping.confirm({ select = false }),
+			}),
+			-- sources for autocompletion
+			sources = cmp.config.sources({
+				{ name = "nvim_lsp" },
+				{ name = "luasnip" }, -- snippets
+				{ name = "buffer" }, -- text within current buffer
+				{ name = "path" }, -- file system paths
+				{ name = "neorg" },
+			}),
 
-      -- configure lspkind for vs-code like pictograms in completion menu
-      formatting = {
-        format = lspkind.cmp_format({
-          maxwidth = 50,
-          ellipsis_char = "...",
-        }),
-      },
-    })
-  end,
+			-- configure lspkind for vs-code like pictograms in completion menu
+			formatting = {
+				format = lspkind.cmp_format({
+					maxwidth = 50,
+					ellipsis_char = "...",
+				}),
+			},
+		})
+	end,
 }

--- a/lua/reconfig-vim/plugins/telescope.lua
+++ b/lua/reconfig-vim/plugins/telescope.lua
@@ -1,37 +1,37 @@
 return {
-  "nvim-telescope/telescope.nvim",
-  branch = "0.1.x",
-  dependencies = {
-    "nvim-lua/plenary.nvim",
-    { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
-    "nvim-tree/nvim-web-devicons",
-    "folke/todo-comments.nvim",
-  },
-  config = function()
-    local telescope = require("telescope")
-    local actions = require("telescope.actions")
+	"nvim-telescope/telescope.nvim",
+	branch = "0.1.x",
+	dependencies = {
+		"nvim-lua/plenary.nvim",
+		{ "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
+		"nvim-tree/nvim-web-devicons",
+		"folke/todo-comments.nvim",
+	},
+	config = function()
+		local telescope = require("telescope")
+		local actions = require("telescope.actions")
 
-    telescope.setup({
-      defaults = {
-        path_display = { "smart" },
-        mappings = {
-          i = {
-            ["<C-k>"] = actions.move_selection_previous, -- move to prev result
-            ["<C-j>"] = actions.move_selection_next, -- move to next result
-            ["<C-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
-          },
-        },
-      },
-    })
+		telescope.setup({
+			defaults = {
+				path_display = { "smart" },
+				mappings = {
+					i = {
+						["<C-k>"] = actions.move_selection_previous, -- move to prev result
+						["<C-j>"] = actions.move_selection_next, -- move to next result
+						["<C-q>"] = actions.send_selected_to_qflist + actions.open_qflist,
+					},
+				},
+			},
+		})
 
-    telescope.load_extension("fzf")
+		telescope.load_extension("fzf")
 
-    -- set keymaps
-    local keymap = vim.keymap -- for conciseness
+		-- set keymaps
+		local keymap = vim.keymap -- for conciseness
 
-    keymap.set("n", "<leader>ff", "<cmd>Telescope find_files<cr>", { desc = "Fuzzy find files in cwd" })
-    keymap.set("n", "<leader>fr", "<cmd>Telescope oldfiles<cr>", { desc = "Fuzzy find recent files" })
-    keymap.set("n", "<leader>fs", "<cmd>Telescope live_grep<cr>", { desc = "Find string in cwd" })
-    keymap.set("n", "<leader>fc", "<cmd>Telescope grep_string<cr>", { desc = "Find string under cursor in cwd" })
-  end,
+		keymap.set("n", "<leader>ff", "<cmd>Telescope find_files<cr>", { desc = "Fuzzy find files in cwd" })
+		keymap.set("n", "<leader>fr", "<cmd>Telescope oldfiles<cr>", { desc = "Fuzzy find recent files" })
+		keymap.set("n", "<leader>fs", "<cmd>Telescope live_grep<cr>", { desc = "Find string in cwd" })
+		keymap.set("n", "<leader>fc", "<cmd>Telescope grep_string<cr>", { desc = "Find string under cursor in cwd" })
+	end,
 }

--- a/lua/reconfig-vim/plugins/treesitter.lua
+++ b/lua/reconfig-vim/plugins/treesitter.lua
@@ -44,6 +44,7 @@ return {
 				"go",
 				"rust",
 				"kotlin",
+				"norg",
 			},
 			incremental_selection = {
 				enable = true,

--- a/lua/reconfig-vim/plugins/windsurf.lua
+++ b/lua/reconfig-vim/plugins/windsurf.lua
@@ -1,0 +1,28 @@
+return {
+	"Exafunction/windsurf.nvim",
+	dependencies = {
+		"nvim-lua/plenary.nvim",
+		"hrsh7th/nvim-cmp",
+	},
+	config = function()
+		require("codeium").setup({
+			detect_proxy = true, -- Enable proxy detection
+
+			api = {
+				port = 443,
+			},
+
+			virtual_text = {
+				enabled = true,
+				idle_delay = 75,
+				map_keys = true,
+				key_bindings = {
+					accept = "<S-Tab>",
+					next = "<M-]>",
+					prev = "<M-[>",
+				},
+			},
+			enable_cmp_source = true,
+		})
+	end,
+}


### PR DESCRIPTION
### Changes included:

1. **LSP Enhancements**
   - Added keymap for LSP quickfix button for faster diagnostics navigation.
   - Added `itex-plus-ls` language server for text files.

2. **Plugin Additions**
   - `image.nvim` for image previews inside Neovim.
   - `LuaSnip` for snippet support.
   - `mini-icons` for enhanced icon support alongside `nvim-web-devicons`.

3. **Neorg Setup**
   - Installed Neorg with template configuration for note-taking workflows.
   - ⚠️ Requires Lua 5.1 for full functionality.

4. **Treesitter**
   - Added Norg parser to `nvim-treesitter` for syntax highlighting and code structure support.

5. **Session Management**
   - Fixed auto-session warning by adding `'localoptions'` to `vim.o.sessionoptions` to preserve filetype and highlighting when restoring sessions.

### Notes
- All plugins have been tested and configured for lazy loading where appropriate.
- This PR ensures that `:checkhealth` now reports a healthy setup.

This setup provides a robust foundation for development, note-taking, and productivity enhancements in Neovim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Neorg added with workspaces, templates, Telescope and LaTeX support; Treesitter and completion integrated.
  - LuaSnip and community snippets added.
  - Image previews and file icons enabled.
  - Windsurf/Codeium AI suggestions integrated.
  - LTeX+ language server added for writing/grammar.

- Enhancements
  - New keybindings for moving lines/blocks and a quickfix code-action.
  - Improved diagnostic signs, highlights, and enabled diagnostic display.
  - Defaults set for conceal level and session persistence.

- Style
  - Plugin config formatting cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->